### PR TITLE
Use --no-prompt and drop --no-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Run `npx deno2node --init` in an empty directory.
 No installation needed. Simply `cd` into the directory of your project, and run:
 
 ```sh
-deno run --no-check --allow-read=. --allow-write=. \
+deno run --no-prompt --allow-read=. --allow-write=. \
   https://deno.land/x/deno2node/src/cli.ts <tsConfigFilePath>
 ```
 


### PR DESCRIPTION
Do not prompt because we want to throw errors which ts-morph can catch.

Do not explicitly specify that the type checking should be skipped, as this is the default behaviour anyway starting from the next Deno release, and it is the default behaviour if `DENO_FUTURE_CHECK` is set already now.