### PR TITLE
fix: use deno path and explicit version in lieu of node path #37

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,4 @@
-import path from "https://deno.land/std/node/path.ts";
+import * as path from "https://deno.land/std@0.178.0/path/mod.ts";
 import { type Config, parse } from "./config.ts";
 import { Project, ts } from "./deps.deno.ts";
 


### PR DESCRIPTION
Closes #37 

This PR:
- updates the import to use deno's `path` from the standard library
- updates the import to use an explicit version